### PR TITLE
fixed wrong state mapping with not open and REJECTED

### DIFF
--- a/lib/modules/platform/scmm/utils.spec.ts
+++ b/lib/modules/platform/scmm/utils.spec.ts
@@ -46,7 +46,7 @@ describe('modules/platform/scmm/utils', () => {
       [{ ...defaultPr, state: 'MERGED' }, 'all', true],
       [{ ...defaultPr, state: 'REJECTED' }, 'all', true],
       [{ ...defaultPr, state: 'OPEN' }, 'open', true],
-      [{ ...defaultPr, state: 'DRAFT' }, 'open', false],
+      [{ ...defaultPr, state: 'DRAFT' }, 'open', true],
       [{ ...defaultPr, state: 'MERGED' }, 'open', false],
       [{ ...defaultPr, state: 'REJECTED' }, 'open', false],
       [{ ...defaultPr, state: 'OPEN' }, '!open', false],

--- a/lib/modules/platform/scmm/utils.ts
+++ b/lib/modules/platform/scmm/utils.ts
@@ -10,7 +10,7 @@ export function matchPrState(pr: Pr, state: PrFilterByState): boolean {
     return true;
   }
 
-  if (state === 'open' && pr.state === 'OPEN') {
+  if (state === 'open' && (pr.state === 'OPEN' || pr.state === 'DRAFT')) {
     return true;
   }
 


### PR DESCRIPTION
## Changes

If a pr is rejected, it now also counts as not open (!open)
This fixes the issue, that rejected prs get constantly reopened.
Additionally drafts are treated correctly as open pull requests.
